### PR TITLE
fix(ci): improve workflow display and reduce redundant builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI # test
+name: CI
 
 on:
   push:
@@ -73,18 +73,27 @@ jobs:
     name: Evaluate NixOS — ${{ matrix.host }}
     runs-on: ubuntu-latest
     needs: [detect-changes, check]
-    if: >-
-      !cancelled() && !failure() &&
-      (needs.detect-changes.outputs.nix == 'true' || github.event_name == 'workflow_dispatch')
+    if: ${{ !cancelled() && !failure() }}
     strategy:
       fail-fast: false
       matrix:
         host: [hasty-desktop, vmware-desktop]
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v15
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - name: Check gate
+        id: gate
+        run: |
+          if [[ "${{ needs.detect-changes.outputs.nix }}" == "true" \
+             || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.gate.outputs.run == 'true'
+        uses: actions/checkout@v4
+      - if: steps.gate.outputs.run == 'true'
+        uses: DeterminateSystems/nix-installer-action@v15
+      - if: steps.gate.outputs.run == 'true'
+        uses: DeterminateSystems/magic-nix-cache-action@v8
       - name: Evaluate ${{ matrix.host }} (dry-run)
+        if: steps.gate.outputs.run == 'true'
         run: |
           nix build \
             ".#nixosConfigurations.${{ matrix.host }}.config.system.build.toplevel" \
@@ -97,18 +106,27 @@ jobs:
     name: Build package — ${{ matrix.package }}
     runs-on: ubuntu-latest
     needs: [detect-changes, check]
-    if: >-
-      !cancelled() && !failure() &&
-      (needs.detect-changes.outputs.packages == 'true' || github.event_name == 'workflow_dispatch')
+    if: ${{ !cancelled() && !failure() }}
     strategy:
       fail-fast: false
       matrix:
         package: [assets, opencode-claude-max-proxy, satty-shot, xwechat]
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v15
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - name: Check gate
+        id: gate
+        run: |
+          if [[ "${{ needs.detect-changes.outputs.packages }}" == "true" \
+             || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
+      - if: steps.gate.outputs.run == 'true'
+        uses: actions/checkout@v4
+      - if: steps.gate.outputs.run == 'true'
+        uses: DeterminateSystems/nix-installer-action@v15
+      - if: steps.gate.outputs.run == 'true'
+        uses: DeterminateSystems/magic-nix-cache-action@v8
       - name: Build ${{ matrix.package }}
+        if: steps.gate.outputs.run == 'true'
         run: |
           nix build \
             ".#packages.x86_64-linux.mypkgs.${{ matrix.package }}" \
@@ -122,15 +140,21 @@ jobs:
     name: Build NixOS — ${{ matrix.host }}
     runs-on: ubuntu-latest
     needs: [detect-changes, check]
-    if: >-
-      !cancelled() && !failure() &&
-      (needs.detect-changes.outputs.lockfile == 'true' || github.event_name == 'workflow_dispatch')
+    if: ${{ !cancelled() && !failure() }}
     strategy:
       fail-fast: false
       matrix:
         host: [hasty-desktop, vmware-desktop]
     steps:
+      - name: Check gate
+        id: gate
+        run: |
+          if [[ "${{ needs.detect-changes.outputs.lockfile }}" == "true" \
+             || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          fi
       - name: Free disk space
+        if: steps.gate.outputs.run == 'true'
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
@@ -140,10 +164,14 @@ jobs:
           large-packages: true
           docker-images: true
           swap-storage: true
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@v15
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - if: steps.gate.outputs.run == 'true'
+        uses: actions/checkout@v4
+      - if: steps.gate.outputs.run == 'true'
+        uses: DeterminateSystems/nix-installer-action@v15
+      - if: steps.gate.outputs.run == 'true'
+        uses: DeterminateSystems/magic-nix-cache-action@v8
       - name: Build ${{ matrix.host }}
+        if: steps.gate.outputs.run == 'true'
         run: |
           nix build \
             ".#nixosConfigurations.${{ matrix.host }}.config.system.build.toplevel" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,26 +127,17 @@ jobs:
 
   # Full NixOS system build — expensive (30–60 min cold).
   # Only runs when flake.lock changes (dependency updates need a full rebuild)
-  # or triggered manually. Both hosts build in parallel via matrix.
+  # or triggered manually. Both hosts are built in a single `nix build` call
+  # which shares the store and parallelises internally.
   build-nixos:
-    name: Build NixOS — ${{ matrix.host }}
+    name: Build NixOS
     runs-on: ubuntu-latest
     needs: [detect-changes, check]
-    if: ${{ !cancelled() && !failure() }}
-    strategy:
-      fail-fast: false
-      matrix:
-        host: [hasty-desktop, vmware-desktop]
+    if: >-
+      !cancelled() && !failure() &&
+      (needs.detect-changes.outputs.lockfile == 'true' || github.event_name == 'workflow_dispatch')
     steps:
-      - name: Check gate
-        id: gate
-        run: |
-          if [[ "${{ needs.detect-changes.outputs.lockfile }}" == "true" \
-             || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          fi
       - name: Free disk space
-        if: steps.gate.outputs.run == 'true'
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
@@ -156,16 +147,13 @@ jobs:
           large-packages: true
           docker-images: true
           swap-storage: true
-      - if: steps.gate.outputs.run == 'true'
-        uses: actions/checkout@v4
-      - if: steps.gate.outputs.run == 'true'
-        uses: DeterminateSystems/nix-installer-action@v15
-      - if: steps.gate.outputs.run == 'true'
-        uses: DeterminateSystems/magic-nix-cache-action@v8
-      - name: Build ${{ matrix.host }}
-        if: steps.gate.outputs.run == 'true'
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v15
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - name: Build all hosts
         run: |
           nix build \
-            ".#nixosConfigurations.${{ matrix.host }}.config.system.build.toplevel" \
+            ".#nixosConfigurations.hasty-desktop.config.system.build.toplevel" \
+            ".#nixosConfigurations.vmware-desktop.config.system.build.toplevel" \
             --no-link \
             --print-build-logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI # test
 
 on:
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,35 +68,22 @@ jobs:
   # Lightweight NixOS evaluation — evaluates the full system closure for each
   # host without building any packages. Catches module option errors, missing
   # imports, and broken attribute paths cheaply.
-  # Runs on every non-documentation Nix change (both hosts in parallel via matrix).
   eval-nixos:
-    name: Evaluate NixOS — ${{ matrix.host }}
+    name: Evaluate NixOS
     runs-on: ubuntu-latest
     needs: [detect-changes, check]
-    if: ${{ !cancelled() && !failure() }}
-    strategy:
-      fail-fast: false
-      matrix:
-        host: [hasty-desktop, vmware-desktop]
+    if: >-
+      !cancelled() && !failure() &&
+      (needs.detect-changes.outputs.nix == 'true' || github.event_name == 'workflow_dispatch')
     steps:
-      - name: Check gate
-        id: gate
-        run: |
-          if [[ "${{ needs.detect-changes.outputs.nix }}" == "true" \
-             || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          fi
-      - if: steps.gate.outputs.run == 'true'
-        uses: actions/checkout@v4
-      - if: steps.gate.outputs.run == 'true'
-        uses: DeterminateSystems/nix-installer-action@v15
-      - if: steps.gate.outputs.run == 'true'
-        uses: DeterminateSystems/magic-nix-cache-action@v8
-      - name: Evaluate ${{ matrix.host }} (dry-run)
-        if: steps.gate.outputs.run == 'true'
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v15
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - name: Evaluate all hosts (dry-run)
         run: |
           nix build \
-            ".#nixosConfigurations.${{ matrix.host }}.config.system.build.toplevel" \
+            ".#nixosConfigurations.hasty-desktop.config.system.build.toplevel" \
+            ".#nixosConfigurations.vmware-desktop.config.system.build.toplevel" \
             --dry-run \
             --print-build-logs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,24 +107,15 @@ jobs:
     name: Build packages
     runs-on: ubuntu-latest
     needs: [detect-changes, check]
-    if: ${{ !cancelled() && !failure() }}
+    if: >-
+      !cancelled() && !failure() &&
+      (needs.detect-changes.outputs.packages == 'true' && needs.detect-changes.outputs.lockfile != 'true'
+      || github.event_name == 'workflow_dispatch')
     steps:
-      - name: Check gate
-        id: gate
-        run: |
-          if [[ "${{ needs.detect-changes.outputs.packages }}" == "true" \
-             && "${{ needs.detect-changes.outputs.lockfile }}" != "true" ]] \
-             || [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          fi
-      - if: steps.gate.outputs.run == 'true'
-        uses: actions/checkout@v4
-      - if: steps.gate.outputs.run == 'true'
-        uses: DeterminateSystems/nix-installer-action@v15
-      - if: steps.gate.outputs.run == 'true'
-        uses: DeterminateSystems/magic-nix-cache-action@v8
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v15
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
       - name: Build all packages
-        if: steps.gate.outputs.run == 'true'
         run: |
           nix build \
             ".#packages.x86_64-linux.mypkgs.assets" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,15 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+    inputs:
+      build-packages:
+        description: Build custom packages
+        type: boolean
+        default: false
+      build-nixos:
+        description: Full NixOS system build
+        type: boolean
+        default: false
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -97,7 +106,7 @@ jobs:
     if: >-
       !cancelled() && !failure() &&
       (needs.detect-changes.outputs.packages == 'true' && needs.detect-changes.outputs.lockfile != 'true'
-      || github.event_name == 'workflow_dispatch')
+      || github.event_name == 'workflow_dispatch' && inputs.build-packages)
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@v15
@@ -122,7 +131,8 @@ jobs:
     needs: [detect-changes, check]
     if: >-
       !cancelled() && !failure() &&
-      (needs.detect-changes.outputs.lockfile == 'true' || github.event_name == 'workflow_dispatch')
+      (needs.detect-changes.outputs.lockfile == 'true'
+      || github.event_name == 'workflow_dispatch' && inputs.build-nixos)
     steps:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,23 +100,21 @@ jobs:
             --dry-run \
             --print-build-logs
 
-  # Custom packages — only built when package sources or flake.nix change.
-  # Skipped for host-config-only or documentation-only changes.
+  # Custom packages — only built when package sources or flake.nix change
+  # AND flake.lock hasn't changed (build-nixos already covers packages in
+  # that case via a full system build).
   build-packages:
-    name: Build package — ${{ matrix.package }}
+    name: Build packages
     runs-on: ubuntu-latest
     needs: [detect-changes, check]
     if: ${{ !cancelled() && !failure() }}
-    strategy:
-      fail-fast: false
-      matrix:
-        package: [assets, opencode-claude-max-proxy, satty-shot, xwechat]
     steps:
       - name: Check gate
         id: gate
         run: |
           if [[ "${{ needs.detect-changes.outputs.packages }}" == "true" \
-             || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+             && "${{ needs.detect-changes.outputs.lockfile }}" != "true" ]] \
+             || [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
           fi
       - if: steps.gate.outputs.run == 'true'
@@ -125,11 +123,14 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@v15
       - if: steps.gate.outputs.run == 'true'
         uses: DeterminateSystems/magic-nix-cache-action@v8
-      - name: Build ${{ matrix.package }}
+      - name: Build all packages
         if: steps.gate.outputs.run == 'true'
         run: |
           nix build \
-            ".#packages.x86_64-linux.mypkgs.${{ matrix.package }}" \
+            ".#packages.x86_64-linux.mypkgs.assets" \
+            ".#packages.x86_64-linux.mypkgs.opencode-claude-max-proxy" \
+            ".#packages.x86_64-linux.mypkgs.satty-shot" \
+            ".#packages.x86_64-linux.mypkgs.xwechat" \
             --no-link \
             --print-build-logs
 


### PR DESCRIPTION
## Summary

- **Fix matrix name expansion**: Merge `eval-nixos` and `build-nixos` matrix jobs into single jobs; all three downstream jobs now use job-level `if` conditions and correctly show "skipped" in the GitHub UI
- **Reduce redundant builds**: Skip `build-packages` when `flake.lock` also changed, since `build-nixos` already performs a full system build that includes all packages
- **Merge package/host builds**: Replace matrix jobs with single `nix build` calls passing multiple targets — nix parallelises internally and deduplicates shared derivations, which is more efficient than separate runners
- **Fix duplicate PR title checks**: Remove `synchronize` trigger from `pr-title.yml` since pushing commits doesn't change the PR title
- **Add concurrency groups**: Cancel stale runs on the same ref/PR to avoid pile-up