### PR TITLE
chore(commit): adopt full conventional commits type set

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -25,7 +25,7 @@ case "$subject" in
     ;;
 esac
 
-pattern='^(feat|fix|docs|chore|refactor)(\([a-z0-9][a-z0-9./-]*\))?: [a-z0-9]'
+pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore)(\([a-z0-9][a-z0-9./-]*\))?!?: [a-z0-9]'
 
 if printf '%s\n' "$subject" | grep -Eq "$pattern"; then
   exit 0
@@ -38,11 +38,15 @@ Expected format:
   type(scope): subject
 
 Allowed types:
-  feat, fix, docs, chore, refactor
+  feat, fix, docs, style, refactor, perf, test, build, ci, chore
+
+Append ! before the colon for breaking changes:
+  feat(module)!: redesign option interface
 
 Examples:
   feat(alacritty): use Nerd Font instead of Nerd Font Mono
   fix(opencode): add node and bun to claude-max-proxy runtime PATH
+  ci(workflows): add selective manual build triggers
   docs(agents): add AGENTS.md for coding agents
   chore(flake.lock): update
 

--- a/.opencode/skills/nix-commit-style/SKILL.md
+++ b/.opencode/skills/nix-commit-style/SKILL.md
@@ -5,26 +5,47 @@ description: Conventional Commits rules for this flake, including preferred type
 
 ## Commit Messages
 
-Use **Conventional Commits** for all new commits:
+Use **Conventional Commits** (v1.0.0) for all new commits:
 
 ```text
 type(scope): subject
+
+[optional body]
+
+[optional footer(s)]
 ```
 
 ### Types
 
-- `feat` -- installs, new integrations, user-visible config additions
-- `fix` -- bug fixes, compatibility fixes, broken runtime behavior
-- `docs` -- documentation changes
-- `chore` -- maintenance, cleanup, package source swaps, removals, version bumps
-- `refactor` -- structure changes without meaningful behavior change (rare in this repo)
+| Type       | When to use                                              |
+|------------|----------------------------------------------------------|
+| `feat`     | new packages, modules, integrations, user-visible config |
+| `fix`      | bug fixes, compatibility fixes, broken runtime behavior  |
+| `docs`     | documentation changes (README, AGENTS.md, etc.)          |
+| `style`    | formatting only (nix fmt, whitespace, semicolons)        |
+| `refactor` | structure changes without meaningful behavior change     |
+| `perf`     | performance improvements (build speed, caching)          |
+| `test`     | adding or updating test cases                            |
+| `build`    | build system changes (flake inputs, overlays)            |
+| `ci`       | CI/CD workflow and pipeline changes                      |
+| `chore`    | maintenance, cleanup, version bumps, removals            |
+
+### Breaking Changes
+
+Append `!` before the colon to flag a breaking change:
+
+```text
+feat(module)!: redesign option interface
+```
+
+A `BREAKING CHANGE:` footer can optionally provide more detail.
 
 ### Scopes
 
 Use the affected component/module as the scope when possible:
 
 ```text
-alacritty, zellij, opencode, readme, flake.lock, home, overlays
+alacritty, zellij, opencode, readme, flake.lock, home, overlays, workflows
 ```
 
 ### Subject Style
@@ -38,8 +59,11 @@ alacritty, zellij, opencode, readme, flake.lock, home, overlays
 ```text
 feat(alacritty): use Nerd Font instead of Nerd Font Mono
 fix(opencode): add node and bun to claude-max-proxy runtime PATH
+ci(workflows): add selective manual build triggers
 docs(agents): add AGENTS.md for coding agents
 chore(flake.lock): update
+refactor(modules): split networking into per-host files
+feat(hyprland)!: replace sway keybindings with hyprland native
 ```
 
 ### Enforcement


### PR DESCRIPTION
## Summary

- **Expand allowed commit types**: Add `style`, `perf`, `test`, `build`, `ci` to the existing `feat`, `fix`, `docs`, `chore`, `refactor`, aligning with the full `@commitlint/config-conventional` set
- **Support breaking changes**: Allow `!` before the colon (e.g. `feat(module)!: ...`) per Conventional Commits v1.0.0
- **Update skill docs**: Rewrite `nix-commit-style` with complete type table, breaking change instructions, and more examples