### PR TITLE
fix(flake): flatten packages to satisfy flake check type constraint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,10 +114,10 @@ jobs:
       - name: Build all packages
         run: |
           nix build \
-            ".#packages.x86_64-linux.mypkgs.assets" \
-            ".#packages.x86_64-linux.mypkgs.opencode-claude-max-proxy" \
-            ".#packages.x86_64-linux.mypkgs.satty-shot" \
-            ".#packages.x86_64-linux.mypkgs.xwechat" \
+            ".#packages.x86_64-linux.assets" \
+            ".#packages.x86_64-linux.opencode-claude-max-proxy" \
+            ".#packages.x86_64-linux.satty-shot" \
+            ".#packages.x86_64-linux.xwechat" \
             --no-link \
             --print-build-logs
 

--- a/flake.nix
+++ b/flake.nix
@@ -85,7 +85,7 @@
           };
 
           formatter = pkgs.nixfmt-rfc-style;
-          packages.mypkgs = import ./pkgs { inherit pkgs; };
+          packages = import ./pkgs { inherit pkgs; };
         };
     };
 }


### PR DESCRIPTION
## Summary

- `packages.mypkgs` was an attrset of derivations, but `flake-parts` requires each `packages.<name>` entry to be a single derivation — `nix flake check` rejects attrsets
- Flatten `packages = import ./pkgs {...}` so `assets`, `opencode-claude-max-proxy`, `satty-shot`, `xwechat` are exposed directly under `packages.*`
- Update `ci.yml` build-packages refs to drop the `.mypkgs.` nesting

## Why it was hidden

The `Evaluate & check flake` job only runs when Nix files change. Recent pushes to `main` only touched non-nix files, so the job was always skipped.

## Test plan

- [x] `nix flake check --no-build` passes locally