### PR TITLE
docs: clarify pkgs dual exposure as overlay and flat flake outputs

### DIFF
--- a/.opencode/skills/nix-code-style/SKILL.md
+++ b/.opencode/skills/nix-code-style/SKILL.md
@@ -63,4 +63,5 @@ Single/few parameters may stay on one line: `{ lib, ... }:`
   `extraSpecialArgs = { inherit inputs; };`.
 - External modules: `imports = [ inputs.foo.nixosModules.bar ];`
 - Internal modules: `self.nixosModules.default`, `self.customOptions`.
-- `pkgs.unstable.*` via overlay, `pkgs.mypkgs.*` via overlay.
+- `pkgs.unstable.*` via overlay, `pkgs.mypkgs.*` via overlay, and custom flake
+  packages exported as flat `packages.<system>.<name>` entries.

--- a/.opencode/skills/nix-new-package/SKILL.md
+++ b/.opencode/skills/nix-new-package/SKILL.md
@@ -8,15 +8,17 @@ description: Workflow and patterns for creating a new custom package derivation 
 ### Overview
 
 `pkgs/default.nix` is a registry using `callPackage` for each derivation.
-Exposed as `pkgs.mypkgs.*` via the overlay in `flake.nix`.
+Exposed internally as `pkgs.mypkgs.*` via the overlay in `flake.nix`, and
+exported from the flake as flat `packages.<system>.<name>` outputs.
 
 ### Steps to Add a New Package
 
 1. Create a new directory under `pkgs/<package-name>/` with a `default.nix`.
 2. Register it in `pkgs/default.nix` using `callPackage`.
 3. Access it as `pkgs.mypkgs.<package-name>` in any module.
-4. Include `meta` with at least `description`.
-5. Run `nix fmt` and verify with `nix build`.
+4. Reference it from the flake as `.#packages.<system>.<package-name>`.
+5. Include `meta` with at least `description`.
+6. Run `nix fmt` and verify with `nix build`.
 
 ### Pattern: Shell Script Wrapper
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ modules/
   home/            # Home Manager modules (share/ = CLI, gui/linux/ = desktop)
 options/           # Centralized custom option declarations (options/default.nix)
 overlays/          # Nixpkgs overlays (unstable, niri, NUR)
-pkgs/              # Custom package derivations (accessed as pkgs.mypkgs.*)
+pkgs/              # Custom package derivations (internal pkgs.mypkgs.*, flat flake packages.* outputs)
 ```
 
 ## Skills

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Personal Nix flake for my Linux desktops (with room for macOS later). It keeps s
 - Treat aesthetics as “calm and coherent enough,” preferring simple, harmonious visuals over flashy themes.
 
 ## Repo layout
-- `flake.nix`: Entrypoint using `flake-parts`, overlays, and a custom package set `mypkgs`.
+- `flake.nix`: Entrypoint using `flake-parts`, overlays, and a custom package set exposed internally as `pkgs.mypkgs.*` and externally as flat flake `packages.*` outputs.
 - `hosts/`: Per-machine definitions combining system modules + home-manager modules and user metadata.
 - `modules/`: Reusable building blocks
   - `system/`: NixOS modules (desktop, peripherals, stylix, secure boot, graphics, etc.)
@@ -56,7 +56,7 @@ Personal Nix flake for my Linux desktops (with room for macOS later). It keeps s
 - **File manager**: Thunar.
 - **Remote desktop**: Sunshine toggle.
 - **Theming**: Stylix plus curated wallpapers/icons in `pkgs/assets`.
-- **CLI base**: zsh + starship, zellij, direnv, git defaults, fzf, custom package set in `modules/home/share`.
+- **CLI base**: zsh + starship, zellij, direnv, git defaults, fzf, custom packages consumed internally via `pkgs.mypkgs.*`.
 
 ## Neovim
 Neovim is enabled via Home Manager and sources my external config (`inputs.nvim-config`, repo: [Hastyshell/diy.nvim](https://github.com/Hastyshell/diy.nvim)) directly into `~/.config/nvim`. Extra build/runtime deps are pre-wrapped (nixd, lua-language-server, stylua, nixfmt, statix, deadnix, rg, fzf, shellcheck/shfmt, sql/toml/yaml/markdown/Actions tooling) so LSPs, formatters, and Telescope work out of the box.


### PR DESCRIPTION
## Summary

- Update `AGENTS.md`, `README.md`, and OpenCode skills to clarify that custom packages are exposed both internally as `pkgs.mypkgs.*` (via overlay) and externally as flat `packages.<system>.<name>` flake outputs
- Add step 4 to `nix-new-package` skill instructing how to reference a package from the flake directly