### PR TITLE
fix(fmt): use nixfmt-tree and add CI formatting check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,10 +60,24 @@ jobs:
   # Fast gate: evaluates all flake outputs and validates their structure.
   # Catches syntax errors, missing imports, and option type mismatches in seconds.
   # Skipped for documentation-only changes (no Nix files touched).
+  fmt:
+    name: Check nix fmt
+    runs-on: ubuntu-latest
+    needs: detect-changes
+    if: needs.detect-changes.outputs.nix == 'true' || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v15
+      - uses: DeterminateSystems/magic-nix-cache-action@v8
+      - name: Run formatter
+        run: nix fmt
+      - name: Verify formatting is clean
+        run: git diff --exit-code
+
   check:
     name: Evaluate & check flake
     runs-on: ubuntu-latest
-    needs: detect-changes
+    needs: [detect-changes, fmt]
     if: needs.detect-changes.outputs.nix == 'true' || github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@v4

--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,7 @@
             };
           };
 
-          formatter = pkgs.nixfmt-rfc-style;
+          formatter = pkgs.nixfmt-tree;
           packages = import ./pkgs { inherit pkgs; };
         };
     };


### PR DESCRIPTION
## Summary
- Switch the flake formatter from `pkgs.nixfmt-rfc-style` to `pkgs.nixfmt-tree` so `nix fmt` runs reliably in project mode.
- Add a dedicated CI job (`Check nix fmt`) that runs `nix fmt` and fails if formatting produces changes (`git diff --exit-code`).
- Make the existing flake check job wait for formatting checks by adding `fmt` to its dependencies.

## Validation
- `nix fmt`
- `nix flake check --no-build`