### PR TITLE
feat: add standalone homeConfigurations for work dev server

### DIFF
--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -1,3 +1,6 @@
 {
-  imports = [ ./nixos ];
+  imports = [
+    ./nixos
+    ./home
+  ];
 }

--- a/hosts/home/default.nix
+++ b/hosts/home/default.nix
@@ -1,0 +1,46 @@
+{
+  self,
+  inputs,
+  withSystem,
+  ...
+}:
+let
+  stateVersion = "25.11";
+  mkHome =
+    {
+      hostname,
+      username,
+      fullName,
+      email,
+      system ? "x86_64-linux",
+      homeModules,
+      ...
+    }:
+    {
+      ${hostname} = withSystem system (
+        { pkgs, ... }:
+        inputs.home-manager.lib.homeManagerConfiguration {
+          inherit pkgs;
+          extraSpecialArgs = { inherit inputs; };
+          modules = homeModules ++ [
+            {
+              home = {
+                inherit username stateVersion;
+                homeDirectory = "/mnt/disk1/${username}";
+              };
+              programs.git.settings.user = {
+                name = fullName;
+                inherit email;
+              };
+            }
+          ];
+        }
+      );
+    };
+  homes = [
+    (import ./hasty-earningd { inherit self; })
+  ];
+in
+{
+  flake.homeConfigurations = builtins.foldl' (x: y: x // y) { } (map mkHome homes);
+}

--- a/hosts/home/hasty-earningd/default.nix
+++ b/hosts/home/hasty-earningd/default.nix
@@ -1,0 +1,11 @@
+{ self, ... }:
+{
+  hostname = "hasty-earningd";
+  username = "tangsiyang";
+  fullName = "Siyang Tang";
+  email = "tangsiyang@selectdb.com";
+  system = "x86_64-linux";
+  homeModules = [
+    self.homeModules.default
+  ];
+}


### PR DESCRIPTION
## Summary

- Add `homeConfigurations` flake output via a new `mkHome` factory in `hosts/home/default.nix`, mirroring the existing `mkHost` pattern for NixOS hosts
- Add first standalone home host `hasty-earningd` for the work dev server where there is no system-level NixOS control
- Import `hosts/home` from `hosts/default.nix`

## Activation

```bash
home-manager switch --flake .#hasty-earningd
```

## Test plan

- [x] `nix fmt` — no formatting changes needed
- [x] `nix flake check` — passes
- [ ] `nix build .#homeConfigurations.hasty-earningd.activationPackage` — builds successfully