### PR TITLE
docs: update docs for standalone homeConfigurations

### DIFF
--- a/.opencode/skills/nix-build/SKILL.md
+++ b/.opencode/skills/nix-build/SKILL.md
@@ -6,8 +6,13 @@ description: Build, apply, test, and lint commands for this NixOS flake — nh, 
 ## Build / Apply
 
 ```bash
+# NixOS hosts
 nh os switch . #hostname          # apply configuration to current host
 nh os test . #hostname            # test without making it the boot default
+
+# Standalone Home Manager hosts (non-NixOS)
+nh home switch . #hostname        # apply home configuration
+
 nix fmt                           # format all Nix files (nixfmt-rfc-style)
 statix check .                    # lint and suggestions
 deadnix .                         # find unused bindings
@@ -20,15 +25,22 @@ nix flake update <input-name>     # update a single input
 No automated tests or flake checks. Verify by building:
 
 ```bash
-# Quick evaluation check (no download/build)
+# NixOS hosts — quick evaluation check (no download/build)
 nix eval .#nixosConfigurations.hasty-desktop.config.system.build.toplevel --no-build
-# Full build check (dry-run)
+# NixOS hosts — full build check (dry-run)
 nix build .#nixosConfigurations.hasty-desktop.config.system.build.toplevel --dry-run
-# Build without applying
+# NixOS hosts — build without applying
 nix build .#nixosConfigurations.hasty-desktop.config.system.build.toplevel
 ```
 
-Replace `hasty-desktop` with `vmware-desktop` to check the other host.
+Replace `hasty-desktop` with `vmware-desktop` to check the other NixOS host.
+
+```bash
+# Standalone Home Manager hosts — evaluation check
+nix eval .#homeConfigurations.hasty-earningd.activationPackage --no-build
+# Standalone Home Manager hosts — build check
+nix build .#homeConfigurations.hasty-earningd.activationPackage
+```
 
 ## Troubleshooting
 

--- a/.opencode/skills/nix-new-module/SKILL.md
+++ b/.opencode/skills/nix-new-module/SKILL.md
@@ -81,9 +81,14 @@ Manager modules, so `custom.linux.desktop.*` flags work across both layers.
 
 ### Host Configuration
 
-Hosts use a `mkHost` factory in `hosts/nixos/default.nix`. Each host directory
+NixOS hosts use a `mkHost` factory in `hosts/nixos/default.nix`. Each host directory
 has `default.nix` (host record: username, modules, homeModules, globalOptions),
 `configuration.nix`, `hardware-configuration.nix` (auto-generated), `home.nix`.
+
+Standalone Home Manager hosts use a `mkHome` factory in `hosts/home/default.nix`.
+Each host directory has a single `default.nix` (host record: hostname, username,
+fullName, email, homeModules). These produce `homeConfigurations` flake outputs
+for use on non-NixOS machines.
 
 ### Module Placement Guide
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,16 @@
 # AGENTS.md
 
 Personal NixOS + Home Manager flake config (**flake-parts**, `x86_64-linux`).
-Two hosts: `hasty-desktop`, `vmware-desktop`. Home Manager as NixOS module.
+NixOS hosts: `hasty-desktop`, `vmware-desktop` (Home Manager as NixOS module).
+Standalone Home Manager hosts: `hasty-earningd` (non-NixOS, `homeConfigurations` output).
 
 ## Repository Layout
 
 ```
 flake.nix          # Entrypoint: inputs, perSystem config, formatter
-hosts/nixos/       # Per-machine host definitions (<hostname>/)
+hosts/
+  nixos/           # NixOS host definitions (<hostname>/)
+  home/            # Standalone Home Manager host definitions (<hostname>/)
 modules/
   home/            # Home Manager modules
     common/        #   Cross-platform CLI/shell tools (included in homeModules.default)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Personal Nix flake for my Linux desktops (with room for macOS later). It keeps s
 ## Repo layout
 - `flake.nix`: Entrypoint using `flake-parts`, overlays, and a custom package set exposed internally as `pkgs.mypkgs.*` and externally as flat flake `packages.*` outputs.
 - `hosts/`: Per-machine definitions combining system modules + home-manager modules and user metadata.
+  - `nixos/`: NixOS system hosts (full system management).
+  - `home/`: Standalone Home Manager hosts for machines without NixOS system-level control.
 - `modules/`: Reusable building blocks
   - `system/`: NixOS modules (desktop, peripherals, stylix, secure boot, graphics, etc.)
   - `home/`: Home Manager modules (shell, editor, terminal, Wayland apps, theming)
@@ -42,8 +44,13 @@ Personal Nix flake for my Linux desktops (with room for macOS later). It keeps s
 - `pkgs/`: Custom packages and assets.
 
 ## Host profiles
+
+### NixOS hosts (`nixosConfigurations`)
 - `hasty-desktop`: Daily driver with NVIDIA, secure boot via lanzaboote, greetd + niri session, waybar, walker, Thunar, Sunshine for remote desktop.
 - `vmware-desktop`: VM-oriented variant sharing the same Wayland stack (niri + walker + waybar + greetd + Thunar + Sunshine) without the NVIDIA/secure-boot bits.
+
+### Standalone Home Manager hosts (`homeConfigurations`)
+- `hasty-earningd`: Work dev server (non-NixOS). Manages only the user environment via standalone Home Manager.
 
 ## Desktop & user stack
 - **WM/session**: Niri from `niri-flake`, Wayland-first environment variables baked in.
@@ -68,14 +75,19 @@ See `options/default.nix` for feature switches like `custom.linux.desktop.wm.nir
 Prereqs: flakes enabled, `nh` installed (e.g., `nix profile install nixpkgs#nh`). Run from the repo root:
 
 ```bash
-# Switch a host
+# Switch a NixOS host
 nh os switch . #hostname
 
-# Dry-run/test
+# Dry-run/test a NixOS host
 nh os test . #hostname
+
+# Switch a standalone Home Manager host
+nh home switch . #hostname
 ```
 
-For new machines, clone the repo, pick/create a host under `hosts/nixos/`, adjust feature flags in `globalOptions`, then run `nh os switch` with the matching `.#hostname`.
+For new NixOS machines, clone the repo, pick/create a host under `hosts/nixos/`, adjust feature flags in `globalOptions`, then run `nh os switch` with the matching `.#hostname`.
+
+For new standalone Home Manager machines (non-NixOS), create a host under `hosts/home/`, then run `nh home switch` with the matching `.#hostname`.
 
 ## Acknowledgements
 - [ryan4yin/nix-config](https://github.com/ryan4yin/nix-config): many configurations were adapted from here.


### PR DESCRIPTION
## Summary

- Update `README.md`: add `hosts/nixos/` and `hosts/home/` to repo layout, split host profiles into NixOS vs standalone HM sections, add `nh home switch` usage and new-machine instructions for non-NixOS hosts
- Update `AGENTS.md`: mention `hasty-earningd` and `homeConfigurations` output, expand repository layout tree with `hosts/home/`
- Update `nix-build` skill: add `nh home switch` command and `homeConfigurations` eval/build verification commands
- Update `nix-new-module` skill: document `mkHome` factory alongside the existing `mkHost` description

## Test plan

- [ ] Docs render correctly on GitHub
- [ ] All mentioned commands and paths match the actual repo structure