### PR TITLE
fix: prepend nix-profile/bin to PATH for nix-portable

### DIFF
--- a/hosts/home/hasty-earningd/default.nix
+++ b/hosts/home/hasty-earningd/default.nix
@@ -7,5 +7,6 @@
   system = "x86_64-linux";
   homeModules = [
     self.homeModules.default
+    { home.sessionVariables.PATH = "$HOME/.nix-profile/bin:$PATH"; }
   ];
 }


### PR DESCRIPTION
## Summary

Close: https://github.com/Hastyshell/nix-config/issues/21

- Add `home.sessionVariables.PATH = "$HOME/.nix-profile/bin:$PATH"` to the `hasty-earningd` host config
- This ensures home-manager managed binaries are on `PATH` when running under nix-portable

## Background

nix-portable doesn't automatically include `~/.nix-profile/bin` in `PATH`, so home-manager installed tools are invisible to the shell without this workaround.

## Test plan

- [ ] Run `home-manager switch` on hasty-earningd
- [ ] Verify `~/.nix-profile/bin` appears at the front of `$PATH` in a new shell