### PR TITLE
fix(opencode): drop --mdns from serve to fix Tailscale accessibility

### DIFF
--- a/modules/home/common/opencode/default.nix
+++ b/modules/home/common/opencode/default.nix
@@ -55,17 +55,17 @@ in
     };
   };
 
-  # Persistent OpenCode server for the Web UI, accessible on the LAN via mDNS.
+  # Persistent OpenCode server for the Web UI.
   # Depends on claude-max-proxy so the proxy is always up before opencode serve starts.
   systemd.user.services.opencode-serve = {
     Unit = {
-      Description = "OpenCode server (Web UI + LAN mDNS)";
+      Description = "OpenCode server (Web UI)";
       After = [ "claude-max-proxy.service" ];
       Requires = [ "claude-max-proxy.service" ];
     };
 
     Service = {
-      ExecStart = "${pkgs.unstable.opencode}/bin/opencode serve --port ${toString servePort} --hostname ${serveHost} --mdns";
+      ExecStart = "${pkgs.unstable.opencode}/bin/opencode serve --port ${toString servePort} --hostname ${serveHost}";
       Environment = [
         "ANTHROPIC_API_KEY=dummy"
         "ANTHROPIC_BASE_URL=${proxyBaseUrl}"

--- a/modules/home/common/opencode/occtl.sh
+++ b/modules/home/common/opencode/occtl.sh
@@ -243,7 +243,6 @@ print_serve_details() {
 
   if curl --silent --output /dev/null --connect-timeout 1 --max-time 2 "$base_url/" 2>/dev/null; then
     printf 'serve-http: reachable at %s\n' "$base_url"
-    printf 'serve-mdns: %s:%s\n' "$DEFAULT_SERVE_MDNS_DOMAIN" "$DEFAULT_SERVE_PORT"
   else
     printf 'serve-http: unreachable at %s\n' "$base_url"
     exit_code=1


### PR DESCRIPTION
## Summary
- Remove `--mdns` flag from `opencode serve` ExecStart — it was preventing the Web UI from being reachable via Tailscale IP
- Clean up mDNS references in comments, unit description, and `occtl` status output

## Test plan
- [ ] `systemctl --user restart opencode-serve.service`
- [ ] Verify Web UI accessible at `http://<tailscale-ip>:8964`
- [ ] `occtl status` output no longer shows stale mDNS info