### PR TITLE
fix: stabilize appimage bwrap launchers

### DIFF
--- a/modules/home/common/codex.nix
+++ b/modules/home/common/codex.nix
@@ -1,0 +1,14 @@
+{ pkgs, ... }:
+let
+  inherit (pkgs) codex;
+in
+{
+  home.packages = with pkgs; [
+    codex
+    mypkgs.codex-desktop-app
+  ];
+
+  home.sessionVariables = {
+    CODEX_CLI_PATH = "${codex}/bin/codex";
+  };
+}

--- a/modules/home/common/default.nix
+++ b/modules/home/common/default.nix
@@ -10,6 +10,7 @@
     ./direnv.nix
     ./pi.nix
     ./opencode
+    ./codex.nix
     ./claude.nix
   ];
 

--- a/modules/home/linux/desktop/default.nix
+++ b/modules/home/linux/desktop/default.nix
@@ -14,6 +14,7 @@
     ./pkgs.nix
     ./niri.nix
     ./swayidle.nix
+    ./vscode.nix
     ./walker
     ./waybar
   ];

--- a/modules/home/linux/desktop/vscode.nix
+++ b/modules/home/linux/desktop/vscode.nix
@@ -1,0 +1,61 @@
+{ lib, pkgs, ... }:
+let
+  monoFont = "JetBrainsMono Nerd Font";
+in
+{
+  programs.vscode = {
+    enable = true;
+    package = pkgs.vscode.fhs;
+
+    profiles.default = {
+      extensions = with pkgs.vscode-extensions; [
+        jnoortheen.nix-ide
+        mkhl.direnv
+
+        llvm-vs-code-extensions.vscode-clangd
+        vadimcn.vscode-lldb
+        ms-vscode-remote.remote-ssh
+        ms-vscode-remote.remote-containers
+        ms-azuretools.vscode-docker
+        catppuccin.catppuccin-vsc
+        rust-lang.rust-analyzer
+        vscodevim.vim
+        eamodio.gitlens
+      ];
+
+      userSettings = {
+        "window.zoomLevel" = 0.75;
+        "editor.fontFamily" = lib.mkForce monoFont;
+        "editor.fontSize" = lib.mkForce 14;
+        "editor.bracketPairColorization.enabled" = true;
+        "editor.guides.bracketPairs" = "active";
+        "[rust]" = {
+          "editor.defaultFormatter" = "rust-lang.rust-analyzer";
+          "editor.formatOnSave" = true;
+        };
+        "[c]" = {
+          "editor.defaultFormatter" = "llvm-vs-code-extensions.vscode-clangd";
+          "editor.formatOnSave" = true;
+        };
+        "[cpp]" = {
+          "editor.defaultFormatter" = "llvm-vs-code-extensions.vscode-clangd";
+          "editor.formatOnSave" = true;
+        };
+        "editor.inlayHints.fontFamily" = lib.mkForce monoFont;
+        "editor.inlineSuggest.fontFamily" = lib.mkForce monoFont;
+        "debug.console.fontFamily" = lib.mkForce monoFont;
+        "scm.inputFontFamily" = lib.mkForce monoFont;
+        "terminal.integrated.fontFamily" = lib.mkForce monoFont;
+        "workbench.colorTheme" = lib.mkForce "Catppuccin Mocha";
+        "vim.handleKeys" = {
+          "<C-p>" = false;
+        };
+      };
+    };
+  };
+
+  home.packages = with pkgs; [
+    rustfmt
+    clang-tools
+  ];
+}

--- a/overlays/default.nix
+++ b/overlays/default.nix
@@ -25,6 +25,7 @@ let
     llm-agents = final: _prev: {
       inherit (inputs.llm-agents.packages.${final.stdenv.hostPlatform.system})
         claude-code
+        codex
         opencode
         pi
         ;

--- a/pkgs/codex-desktop-app/default.nix
+++ b/pkgs/codex-desktop-app/default.nix
@@ -38,18 +38,31 @@ let
   inherit (sources.${system} or (throw "Unsupported system: ${system}")) src icon;
 in
 appimageTools.wrapType2 {
-  inherit pname version src meta;
+  inherit
+    pname
+    version
+    src
+    meta
+    ;
 
   extraInstallCommands = ''
+    mv "$out/bin/${pname}" "$out/bin/.${pname}-bwrap"
+    cat > "$out/bin/${pname}" <<EOF
+    #!${stdenvNoCC.shell}
+    "$out/bin/.${pname}-bwrap" "\$@"
+    EOF
+    chmod +x "$out/bin/${pname}"
+
     install -m 444 -D ${icon} $out/share/icons/hicolor/512x512/apps/${pname}.png
     install -m 444 -D /dev/stdin $out/share/applications/${pname}.desktop <<EOF
     [Desktop Entry]
     Name=Codex
     Comment=Codex desktop app
-    Exec=${pname}
+    Exec=${pname} --no-sandbox %U
     Icon=${pname}
     Terminal=false
     Type=Application
+    StartupWMClass=Codex
     Categories=Development;
     EOF
   '';

--- a/pkgs/codex-desktop-app/default.nix
+++ b/pkgs/codex-desktop-app/default.nix
@@ -1,0 +1,60 @@
+{
+  lib,
+  appimageTools,
+  codex,
+  fetchurl,
+  stdenvNoCC,
+  ...
+}:
+let
+  inherit (stdenvNoCC.hostPlatform) system;
+
+  pname = "codex-desktop-app";
+  version = "26.506.31421-launcher.27";
+
+  meta = {
+    description = "Unofficial Linux launcher for the Codex desktop app";
+    homepage = "https://github.com/better-slop/codex-app-linux";
+    license = lib.licenses.unfree;
+    sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    maintainers = with lib.maintainers; [ hastyshell ];
+    mainProgram = pname;
+    platforms = [ "x86_64-linux" ];
+  };
+
+  sources = {
+    x86_64-linux = {
+      src = fetchurl {
+        url = "https://github.com/better-slop/codex-app-linux/releases/download/v${version}/codex-app-linux-${version}-x64.AppImage";
+        hash = "sha256-2nwDOseyY3feznolzRU1oVKnq6OETveN9nusL/fVNm0=";
+      };
+      icon = fetchurl {
+        url = "https://github.com/better-slop/codex-app-linux/releases/download/v${version}/codex-app-linux-${version}-x64.png";
+        hash = "sha256-HJJuOAv+alD0Bkjdm8XeiNpycVRkka35nschcuF99qA=";
+      };
+    };
+  };
+
+  inherit (sources.${system} or (throw "Unsupported system: ${system}")) src icon;
+in
+appimageTools.wrapType2 {
+  inherit pname version src meta;
+
+  extraInstallCommands = ''
+    install -m 444 -D ${icon} $out/share/icons/hicolor/512x512/apps/${pname}.png
+    install -m 444 -D /dev/stdin $out/share/applications/${pname}.desktop <<EOF
+    [Desktop Entry]
+    Name=Codex
+    Comment=Codex desktop app
+    Exec=${pname}
+    Icon=${pname}
+    Terminal=false
+    Type=Application
+    Categories=Development;
+    EOF
+  '';
+
+  extraBwrapArgs = [
+    "--setenv CODEX_CLI_PATH ${codex}/bin/codex"
+  ];
+}

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -1,6 +1,7 @@
 { pkgs, ... }:
 {
   assets = pkgs.callPackage ./assets { };
+  codex-desktop-app = pkgs.callPackage ./codex-desktop-app { };
   satty-shot = pkgs.callPackage ./satty-shot { };
   xwechat = pkgs.callPackage ./wechat { };
 }

--- a/pkgs/wechat/default.nix
+++ b/pkgs/wechat/default.nix
@@ -55,16 +55,14 @@ appimageTools.wrapAppImage {
 
   src = appimageContents;
 
-  # nativeBuildInputs = [ makeWrapper ];
-
-  # note:
-  # It is vital to exec wechat with command
-  # sh -c "${pname} > /tmp/wechat.log 2>&1"
-  # since wechat seems to need a stdout/stderr
-  # otherwise it cannot start with app launcher
-  # properly, or can only run with Terminal=true.
-  # It sucks!
   extraInstallCommands = ''
+    mv "$out/bin/${pname}" "$out/bin/.${pname}-bwrap"
+    cat > "$out/bin/${pname}" <<EOF
+    #!${stdenvNoCC.shell}
+    "$out/bin/.${pname}-bwrap" "\$@"
+    EOF
+    chmod +x "$out/bin/${pname}"
+
     # wrapProgram $out/bin/${pname} \
     #    --set GTK_IM_MODULE "fcitx" \
     #    --set QT_IM_MODULE "fcitx" \
@@ -78,7 +76,7 @@ appimageTools.wrapAppImage {
 
     cat > $out/share/applications/${pname}.desktop <<EOF
     [Desktop Entry]
-    Exec=sh -c "${pname} > /tmp/wechat.log 2>&1"
+    Exec=${pname}
     Icon=wechat
     Name=wechat
     Terminal=false


### PR DESCRIPTION
## Summary

- Keep the `appimageTools`-generated bwrap launchers as hidden implementation binaries.
- Add small public shell wrappers for `codex-desktop-app` and `wechat` that invoke the hidden bwrap launchers without `exec`.
- Remove the WeChat desktop-entry log redirection workaround and make the Codex desktop entry pass `--no-sandbox`.

## Rationale

Nix `appimageTools` launchers end by `exec`ing `bwrap` with `--die-with-parent`. Under niri/Walker desktop activation, applications are direct-spawned through short-lived launcher/scope processes. When the public wrapper is replaced by `bwrap` via `exec`, `bwrap` can observe that its parent disappeared and terminate the sandbox before the application creates a window.

Keeping a tiny shell wrapper alive as the public executable gives `bwrap` a stable parent process while preserving the generated sandbox launcher unchanged.

The previous WeChat desktop entry used:

```ini
Exec=sh -c "wechat > /tmp/wechat.log 2>&1"
```

That worked because the shell stayed alive as the parent process, not because WeChat requires output to be redirected into a log file.

## Verification

- `nix fmt -- pkgs/codex-desktop-app/default.nix pkgs/wechat/default.nix`
- `nix build .#codex-desktop-app .#xwechat`
- Launched `result/bin/codex-desktop-app --no-sandbox` via `niri msg action spawn` and confirmed the Codex window appeared.
- Launched `result/bin/wechat` via `niri msg action spawn` and confirmed the Weixin window appeared.
